### PR TITLE
Feat configurable execution

### DIFF
--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Runs daily at 00:00 UTC
   workflow_dispatch:     # Manual trigger
+    inputs:
+      environment:
+        type: choice
+        description: 'environment to run the tests against'
+        options:
+          - dev
+          - prod
+        required: true
+        default: dev
 
 jobs:
   robot-tests:
@@ -24,7 +33,7 @@ jobs:
 
       - name: Run Robot Framework tests
         run: |
-          pabot --testlevelsplit --processes 8  --outputdir ./reports ./online_bookstore
+          pabot --testlevelsplit --processes 8  --outputdir  ./reports --variable env:{{ github.event.inputs.environment }} ./online_bookstore
         continue-on-error: true
 
       - name: Upload Robot Framework reports

--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Robot Framework tests
         run: |
-          pabot --testlevelsplit --processes 8 --outputdir ./reports --variable env:{{ github.event.inputs.environment }} ./online_bookstore
+          pabot --testlevelsplit --processes 8 --outputdir ./reports --variable env:${{ github.event.inputs.environment }} ./online_bookstore
         continue-on-error: true
 
       - name: Upload Robot Framework reports

--- a/.github/workflows/run-all-tests.yaml
+++ b/.github/workflows/run-all-tests.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Robot Framework tests
         run: |
-          pabot --testlevelsplit --processes 8  --outputdir  ./reports --variable env:{{ github.event.inputs.environment }} ./online_bookstore
+          pabot --testlevelsplit --processes 8 --outputdir ./reports --variable env:{{ github.event.inputs.environment }} ./online_bookstore
         continue-on-error: true
 
       - name: Upload Robot Framework reports

--- a/online_bookstore/api_paths.resource
+++ b/online_bookstore/api_paths.resource
@@ -1,5 +1,8 @@
+*** Settings ***
+Variables    ${CURDIR}/common/env_vars.py
+
 *** Variables ***
-${BASE_URL}=  https://fakerestapi.azurewebsites.net
+${BASE_URL}=  ${app_url}[${env}]
 ${BOOKS_URL}=  /api/v1/Books/
 ${AUTHORS_URL}=  /api/v1/Authors/
 ${AUTHORS_PER_BOOK_ID_URL}=  ${AUTHORS_URL}authors/books/

--- a/online_bookstore/common/env_vars.py
+++ b/online_bookstore/common/env_vars.py
@@ -1,0 +1,4 @@
+app_url = {
+    "dev" : "https://fakerestapi.azurewebsites.net",
+    "prod" : "https://fakerestapi-prod.azurewebsites.net"
+}


### PR DESCRIPTION
adding configurability of the workflow (and manual runs) by cli parameter "env", with defined options "dev" and "prod", where "prod" has a non-existing URL defined and "dev" is the original fake API. this is just for demonstrating the configurability by CLI params both for manual and CI runs